### PR TITLE
Install 'php-mbstring' package.

### DIFF
--- a/docs/source/installing/debian9.rst
+++ b/docs/source/installing/debian9.rst
@@ -30,7 +30,7 @@ Instalación de paquetes en Debian GNU/Linux
 .. code:: bash
 
     apt install apache2 libapache2-mod-php php php-curl php-mysqlnd php-curl \
-    php-gd php-json mariadb-server php-ldap
+    php-gd php-json mariadb-server php-ldap php-mbstring
     
     service apache2 restart
 


### PR DESCRIPTION
Package include functions like 'mb_strlen' which is required by syspass.

```
PHP Fatal error:  Uncaught Error: Call to undefined function mb_strlen() in /var/www/html/sysPass/inc/BaseFunctions.php:67\nStack trace:\n#0 /var/www/html/sysPass/inc/themes/material-blue/inc/Icons.class.php(46): __(
[...]
```