### PR TITLE
Install 'php-xml' package.

### DIFF
--- a/docs/source/installing/debian9.rst
+++ b/docs/source/installing/debian9.rst
@@ -30,7 +30,7 @@ Instalación de paquetes en Debian GNU/Linux
 .. code:: bash
 
     apt install apache2 libapache2-mod-php php php-curl php-mysqlnd php-curl \
-    php-gd php-json mariadb-server php-ldap php-mbstring
+    php-gd php-json mariadb-server php-ldap php-mbstring php-xml
     
     service apache2 restart
 


### PR DESCRIPTION
Package enable 'dom' php extension.

```
PHP Fatal error:  Uncaught Error: Class 'DOMDocument' not found in /var/www/html/sysPass/inc/SP/Storage/XmlHandler.class.php:105trace:\n#0 /var/www/html/sysPass/inc/themes/material-blue/inc/Icons.class.php(46): __(
[...]
```