### PR TITLE
Update security.rst

### DIFF
--- a/docs/source/application/security.rst
+++ b/docs/source/application/security.rst
@@ -18,7 +18,7 @@ In order to limit the access to the directories through Apache, '.htaccess' file
 
 .. code:: Apache
 
-  # Apache 2.4
+  # Apache 2.4 (after 2.4.16)
   <Directory "/var/www/html/sysPass">
     Options -Indexes -FollowSymLinks -Includes -ExecCGI
     <RequireAny>
@@ -31,6 +31,23 @@ In order to limit the access to the directories through Apache, '.htaccess' file
   <Directory "/var/www/html/sysPass/public">
     Require all granted
   </Directory>
+
+.. code:: Apache
+
+  # Apache 2.4 (before 2.4.16)
+  <Directory "/var/www/html/sysPass">
+    Options -Indexes -FollowSymLinks -Includes -ExecCGI
+    <RequireAny>
+        Require expr %{REQUEST_URI} =~ m#.*/index\.php(\?r=)?#
+        Require expr %{REQUEST_URI} =~ m#.*/api\.php$#
+        Require expr %{REQUEST_URI} =~ m#^$#
+    </RequireAny>
+  </Directory>
+
+  <Directory "/var/www/html/sysPass/public">
+    Require all granted
+  </Directory>
+
 
 .. danger::
   'app/config' directory shouldn't be accessible through the web server, it could reveal private data.


### PR DESCRIPTION
With regular centOS 7.6 (1819) Apache 2.4.6 is installed by default.
If you use the given Expression startup of apache fails with the following error:
"Cannot parse expression in require line: syntax error, unexpected $end"

As stated in the apache docs, before 2.4.16 you need to omit the double quotes.
https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html#reqexpr
"The syntax is described in the ap_expr documentation. Before httpd 2.4.16, the surrounding double-quotes MUST be omitted."