### PR TITLE
Update debian9.rst

### DIFF
--- a/docs/source/installing/debian9.rst
+++ b/docs/source/installing/debian9.rst
@@ -80,6 +80,10 @@ From sysPass root directory, download and install Composer (https://getcomposer.
     php composer-setup.php
     php -r "unlink('composer-setup.php');"
 
+.. note::
+
+  You may take the newest install instructions from composer-website (https://getcomposer.org/download/), as the Hashes of the composer-setup changes with new releases. Otherwise the verification command end in "Installert corrupt".
+
 Then install sysPass dependencies
 
 .. code:: bash


### PR DESCRIPTION
added notice with reference to official composer Download website.
If using the current command this would end into a "Installer corrupt" state, due to new hash of the newer composer-setup release.