### PR TITLE
Match / as valid URI

### DIFF
--- a/docs/source/application/security.rst
+++ b/docs/source/application/security.rst
@@ -40,7 +40,7 @@ In order to limit the access to the directories through Apache, '.htaccess' file
     <RequireAny>
         Require expr %{REQUEST_URI} =~ m#.*/index\.php(\?r=)?#
         Require expr %{REQUEST_URI} =~ m#.*/api\.php$#
-        Require expr %{REQUEST_URI} =~ m#^$#
+        Require expr %{REQUEST_URI} =~ m#^/?$#
     </RequireAny>
   </Directory>
 


### PR DESCRIPTION
Most of the new browsers will automatically rewrite the URLs to append trailing slash. This fix will match empty URI or `/` in URI.

```
curl -v https://localhost
* Rebuilt URL to: https://localhost/
```

In this case, apache will serve default page or "noindex" page in my case.